### PR TITLE
DualSense Wireless Controller recognition fix

### DIFF
--- a/addons/guide/ui/renderers/controllers/playstation/playstation_controller_renderer.tscn
+++ b/addons/guide/ui/renderers/controllers/playstation/playstation_controller_renderer.tscn
@@ -22,7 +22,7 @@
 [ext_resource type="Texture2D" uid="uid://bw2h7xxdtp31i" path="res://addons/guide/ui/renderers/controllers/playstation/icons/PS5_Share.png" id="20_p3s2m"]
 
 [node name="ControllerRenderer" instance=ExtResource("1_bq6gh")]
-controller_name_matches = Array[String](["PlayStation", "PS3", "PS4", "PS5"])
+controller_name_matches = Array[String](["DualSense Wireless Controller", "PlayStation", "PS3", "PS4", "PS5"])
 a_button = ExtResource("2_oqi6t")
 b_button = ExtResource("3_m332j")
 x_button = ExtResource("4_dqhg4")

--- a/addons/guide/ui/text_providers/controllers/playstation/playstation_controller_text_provider.gd
+++ b/addons/guide/ui/text_providers/controllers/playstation/playstation_controller_text_provider.gd
@@ -1,7 +1,7 @@
 extends "res://addons/guide/ui/text_providers/controllers/controller_text_provider.gd"
 
 func _controller_names() -> Array[String]:
-	return ["Playstation", "PS3", "PS4", "PS5"]	
+	return ["DualSense Wireless Controller", "Playstation", "PS3", "PS4", "PS5"]	
 	
 func _a_button_name() -> String:
 	return "Cross"


### PR DESCRIPTION
Fixes #42  

DualSense Wireless Controller recognition so Icons display correctly. This is the controller that comes with the Playstation 5.

- Adds "DualSense Wireless Controller" to `playstation_controller_text_provider.gd` `_controller_names` array function
- Adds "DualSense Wireless Controller" to `playstation_controller_renderer.tscn``controller_name_matches` variable within the `ControllerRenderer` node exports.


On Godot 4.4 with DualSense Wireless Controller before these changes
<img width="1174" alt="Screenshot 2025-03-22 at 5 04 55 p m" src="https://github.com/user-attachments/assets/f3509c4d-82de-425f-ba6b-bab2ea8f04de" />

After
<img width="1173" alt="Screenshot 2025-03-22 at 5 03 59 p m" src="https://github.com/user-attachments/assets/7528e1f9-8cda-4148-b610-6c32a868147c" />
