### PR TITLE
Prevent GUIDETriggerPressed from triggering if its input mapping is held while it becomes active

### DIFF
--- a/addons/guide/guide_input_mapping.gd
+++ b/addons/guide/guide_input_mapping.gd
@@ -108,6 +108,11 @@ func _initialize() -> void :
 			GUIDETrigger.GUIDETriggerType.IMPLICIT:
 				_implicit_count += 1
 		_trigger_list.append(trigger)
+
+		# prevents the mapping from triggering if the input is held while
+		# the mapping becomes active.
+		if trigger is GUIDETriggerPressed:
+			trigger._last_value = Vector3.ONE
 		
 		# collect the hold threshold for hinting the UI about how long
 		# the input must be held down. This is only relevant for hold triggers

--- a/addons/guide/guide_input_mapping.gd
+++ b/addons/guide/guide_input_mapping.gd
@@ -112,7 +112,8 @@ func _initialize() -> void :
 		# prevents the mapping from triggering if the input is held while
 		# the mapping becomes active.
 		if trigger is GUIDETriggerPressed:
-			trigger._last_value = Vector3.ONE
+			if not trigger.triggerable_immediately:
+				trigger._last_value = Vector3.ONE
 		
 		# collect the hold threshold for hinting the UI about how long
 		# the input must be held down. This is only relevant for hold triggers

--- a/addons/guide/triggers/guide_trigger_pressed.gd
+++ b/addons/guide/triggers/guide_trigger_pressed.gd
@@ -4,6 +4,10 @@
 class_name GUIDETriggerPressed
 extends GUIDETrigger
 
+## If [code]true[/code], the relevant [GUIDEAction] will be triggered if the [GUIDEMappingContext]
+## is made active while the relevant input mapping is actuated.[br]
+## If [code]false[/code], the relevant input mapping must be in an unactuated state before it will be triggered.
+@export var triggerable_immediately:bool = true
 
 func _update_state(input:Vector3, delta:float, value_type:GUIDEAction.GUIDEActionValueType) -> GUIDETriggerState:
 	if _is_actuated(input, value_type):


### PR DESCRIPTION
This resolves #67, might not be the best way, though. I'm unfortunately not deeply familiar with the internals of this plugin.