### PR TITLE
Add cancel detection support to binding dialog

### DIFF
--- a/addons/guide/editor/binding_dialog/binding_dialog.gd
+++ b/addons/guide/editor/binding_dialog/binding_dialog.gd
@@ -16,6 +16,7 @@ signal input_selected(input:GUIDEInput)
 @onready var _select_3d_button:Button = %Select3DButton
 @onready var _instructions_label:Label = %InstructionsLabel
 @onready var _accept_detection_button:Button = %AcceptDetectionButton
+@onready var _cancel_detection_button = %CancelDetectionButton
 @onready var _input_detector:GUIDEInputDetector = %InputDetector
 @onready var _detect_bool_button:Button = %DetectBoolButton
 @onready var _detect_1d_button:Button = %Detect1DButton
@@ -24,6 +25,7 @@ signal input_selected(input:GUIDEInput)
 
 var _scanner:ClassScanner
 var _last_detected_input:GUIDEInput
+var _detection_cancelled: bool = false
 
 	
 func initialize(scanner:ClassScanner):
@@ -39,6 +41,8 @@ func _setup_dialog():
 	_show_inputs_of_value_type(GUIDEAction.GUIDEActionValueType.BOOL)
 	_instructions_label.text = tr("Press one of the buttons above to detect an input.")
 	_accept_detection_button.visible = false
+	_cancel_detection_button.visible = false
+
 	
 
 func _on_close_requested():
@@ -106,10 +110,15 @@ func _on_input_detector_detection_started():
 
 
 func _on_input_detector_input_detected(input:GUIDEInput):
+	if input == null or _detection_cancelled:
+		_detection_cancelled = false
+		return
+
 	_instructions_label.visible = false
 	_input_display.visible = true
 	_input_display.input = input
 	_accept_detection_button.visible = true
+	_cancel_detection_button.visible = false
 	_last_detected_input = input
 
 
@@ -118,9 +127,14 @@ func _begin_detect_input(type:GUIDEAction.GUIDEActionValueType):
 	_instructions_label.visible = true
 	_instructions_label.text = tr("Get ready...")
 	_accept_detection_button.visible = false
+	_cancel_detection_button.visible = true
 	_input_display.visible = false
 	_input_detector.detect(type)
 	
+func _end_detect_input():
+	_input_detector.abort_detection()
+	_detection_cancelled = true
+	_instructions_label.text = tr("Press one of the buttons above to detect an input.")
 
 func _on_detect_bool_button_pressed():
 	_detect_bool_button.release_focus()

--- a/addons/guide/editor/binding_dialog/binding_dialog.tscn
+++ b/addons/guide/editor/binding_dialog/binding_dialog.tscn
@@ -115,11 +115,22 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 6
 
-[node name="AcceptDetectionButton" type="Button" parent="MarginContainer/MarginContainer/HBoxContainer/MarginContainer/MarginContainer/VBoxContainer"]
+[node name="HBoxContainer2" type="HBoxContainer" parent="MarginContainer/MarginContainer/HBoxContainer/MarginContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+theme_override_constants/separation = 8
+alignment = 1
+
+[node name="AcceptDetectionButton" type="Button" parent="MarginContainer/MarginContainer/HBoxContainer/MarginContainer/MarginContainer/VBoxContainer/HBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 4
 text = "Accept"
+
+[node name="CancelDetectionButton" type="Button" parent="MarginContainer/MarginContainer/HBoxContainer/MarginContainer/MarginContainer/VBoxContainer/HBoxContainer2"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 4
+text = "Cancle"
 
 [node name="MarginContainer2" type="MarginContainer" parent="MarginContainer/MarginContainer/HBoxContainer"]
 layout_mode = 2
@@ -207,7 +218,8 @@ script = ExtResource("3_c6q6r")
 [connection signal="pressed" from="MarginContainer/MarginContainer/HBoxContainer/MarginContainer/MarginContainer/VBoxContainer/HBoxContainer/Detect1DButton" to="." method="_on_detect_1d_button_pressed"]
 [connection signal="pressed" from="MarginContainer/MarginContainer/HBoxContainer/MarginContainer/MarginContainer/VBoxContainer/HBoxContainer/Detect2DButton" to="." method="_on_detect_2d_button_pressed"]
 [connection signal="pressed" from="MarginContainer/MarginContainer/HBoxContainer/MarginContainer/MarginContainer/VBoxContainer/HBoxContainer/Detect3DButton" to="." method="_on_detect_3d_button_pressed"]
-[connection signal="pressed" from="MarginContainer/MarginContainer/HBoxContainer/MarginContainer/MarginContainer/VBoxContainer/AcceptDetectionButton" to="." method="_on_accept_detection_button_pressed"]
+[connection signal="pressed" from="MarginContainer/MarginContainer/HBoxContainer/MarginContainer/MarginContainer/VBoxContainer/HBoxContainer2/AcceptDetectionButton" to="." method="_on_accept_detection_button_pressed"]
+[connection signal="pressed" from="MarginContainer/MarginContainer/HBoxContainer/MarginContainer/MarginContainer/VBoxContainer/HBoxContainer2/CancelDetectionButton" to="." method="_end_detect_input"]
 [connection signal="pressed" from="MarginContainer/MarginContainer/HBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/HBoxContainer/SelectBoolButton" to="." method="_on_select_bool_button_pressed"]
 [connection signal="pressed" from="MarginContainer/MarginContainer/HBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/HBoxContainer/Select1DButton" to="." method="_on_select_1d_button_pressed"]
 [connection signal="pressed" from="MarginContainer/MarginContainer/HBoxContainer/MarginContainer2/MarginContainer/VBoxContainer/HBoxContainer/Select2DButton" to="." method="_on_select_2d_button_pressed"]

--- a/addons/guide/remapping/guide_input_detector.gd
+++ b/addons/guide/remapping/guide_input_detector.gd
@@ -224,9 +224,6 @@ func _input(event:InputEvent) -> void:
 	# feed the event into the state
 	_input_state._input(event)
 
-	# while detecting, we're the only ones consuming input and we eat this input
-	# to not accidentally trigger built-in Godot mappings (e.g. UI stuff)
-	get_viewport().set_input_as_handled()
 	# but we still feed it into GUIDE's global state so this state stays 
 	# up to date. This should have no effect because we disabled all mapping
 	# contexts.
@@ -257,7 +254,12 @@ func _input(event:InputEvent) -> void:
 				_try_detect_axis_2d(event)
 			GUIDEAction.GUIDEActionValueType.AXIS_3D:
 				_try_detect_axis_3d(event)
-
+		# Rather then always eating the event, we only eat it if we actually
+		# detected something. This way other input handling (e.g. UI) can still
+		# call_deferred is used here to allow UI elements to also process the event
+		# before we mark it as handled.
+		# it weird i know, but it works.  
+		get_viewport().set_input_as_handled.call_deferred()
 
 func _matches_device_types(event:InputEvent) -> bool:
 	if _device_types.is_empty():


### PR DESCRIPTION
Introduces a CancelDetectionButton to the binding dialog UI and implements logic in binding_dialog.gd to allow users to cancel input detection. Updates guide_input_detector.gd to improve input event handling and event consumption, ensuring that detection can be aborted cleanly and UI remains responsive.

Fix #84 