### PR TITLE
add texture rendering function

### DIFF
--- a/addons/guide/ui/guide_input_formatter.gd
+++ b/addons/guide/ui/guide_input_formatter.gd
@@ -208,6 +208,30 @@ func _materialized_as_richtext_async(input:MaterializedInput) -> String:
 		
 	return separator.join(parts)
 		
+## Formats the action input as a Texture2D. This function
+## is async as icons may need to be rendered in the background which can take a few frames, so 
+## you will need to await on it.
+func action_as_texture_async(action:GUIDEAction) -> Texture2D:
+	print(_materialize_action_input(action))
+	return await _materialized_as_texture_async(_materialize_action_input(action))
+
+## Renders materialized input as texture.
+func _materialized_as_texture_async(input:MaterializedInput) -> Texture2D:
+	_ensure_readiness()
+	if input is MaterializedSimpleInput:
+		var icon:Texture2D = null
+		for renderer in _icon_renderers:
+			if renderer.supports(input.input):
+				icon = await _icon_maker.make_icon(input.input, renderer, _icon_size)
+				# first renderer wins
+				break
+		if icon == null:
+			push_warning("No renderer found for input ", input)
+			return null
+
+		return icon
+
+	return await _materialized_as_texture_async(input.parts[0])
 
 func _separator_for_input(input:MaterializedInput) -> String:
 	if input is MaterializedMixedInput:

--- a/addons/guide/ui/guide_input_formatter.gd
+++ b/addons/guide/ui/guide_input_formatter.gd
@@ -23,7 +23,7 @@ static var _icon_renderers:Array[GUIDEIconRenderer] = []
 static var _text_providers:Array[GUIDETextProvider] = []
 static var _is_ready:bool = false
 
-## Separator to separate mixed input. 
+## Separator to separate mixed input.
 static var mixed_input_separator:String = ", "
 ## Separator to separate chorded input.
 static var chorded_input_separator:String = " + "
@@ -37,17 +37,17 @@ var _icon_size:int
 static func _ensure_readiness():
 	if _is_ready:
 		return
-		
+
 	# reconnect to an icon maker that might be there
-	var root = Engine.get_main_loop().root	
+	var root = Engine.get_main_loop().root
 	for child in root.get_children():
 		if child is IconMaker:
 			_icon_maker = child
-			
+
 	if _icon_maker == null:
 		_icon_maker = preload("icon_maker/icon_maker.tscn").instantiate()
 		root.add_child.call_deferred(_icon_maker)
-	
+
 	add_icon_renderer(KeyRenderer.instantiate())
 	add_icon_renderer(MouseRenderer.instantiate())
 	add_icon_renderer(TouchRenderer.instantiate())
@@ -57,29 +57,29 @@ static func _ensure_readiness():
 	add_icon_renderer(PlayStationRenderer.instantiate())
 	add_icon_renderer(SwitchRenderer.instantiate())
 	add_icon_renderer(FallbackRenderer.instantiate())
-	
+
 	add_text_provider(DefaultTextProvider.new())
 	add_text_provider(XboxTextProvider.new())
 	add_text_provider(PlayStationTextProvider.new())
 	add_text_provider(SwitchTextProvider.new())
-	
+
 	_is_ready = true
 
 
-## This will clean up the rendering infrastructure used for generating 
+## This will clean up the rendering infrastructure used for generating
 ## icons. Note that in a normal game you will have no need to call this
 ## as the infrastructure is needed throughout the run of your game.
 ## It might be useful in tests though, to get rid of spurious warnings
 ## about orphaned nodes.
 static func cleanup():
 	_is_ready = false
-		
+
 	# free all the nodes to avoid memory leaks
 	for renderer in _icon_renderers:
 		renderer.queue_free()
-		
+
 	_icon_renderers.clear()
-	
+
 	_text_providers.clear()
 	if is_instance_valid(_icon_maker):
 		_icon_maker.queue_free()
@@ -94,18 +94,18 @@ func _init(icon_size:int = 32, resolver:Callable = func(action) -> GUIDEActionMa
 static func add_icon_renderer(renderer:GUIDEIconRenderer) -> void:
 	_icon_renderers.append(renderer)
 	_icon_renderers.sort_custom(func(r1, r2): return r1.priority < r2.priority)
-	
+
 ## Removes an icon renderer.
 static func remove_icon_renderer(renderer:GUIDEIconRenderer) -> void:
 	_icon_renderers.erase(renderer)
-	
+
 ## Adds a text provider for rendering text.
 static func add_text_provider(provider:GUIDETextProvider) -> void:
 	_text_providers.append(provider)
 	_text_providers.sort_custom(func(r1, r2): return r1.priority < r2.priority)
 
-	
-## Removes a text provider	
+
+## Removes a text provider
 static func remove_text_provider(provider:GUIDETextProvider) -> void:
 	_text_providers.erase(provider)
 
@@ -127,12 +127,12 @@ static func for_context(context:GUIDEMappingContext, icon_size:int = 32) -> GUID
 			if mapping.action == action:
 				return  mapping
 		return null
-		
+
 	return GUIDEInputFormatter.new(icon_size, resolver)
-	
-	
+
+
 ## Formats the action input as richtext with icons suitable for a RichTextLabel. This function
-## is async as icons may need to be rendered in the background which can take a few frames, so 
+## is async as icons may need to be rendered in the background which can take a few frames, so
 ## you will need to await on it.
 func action_as_richtext_async(action:GUIDEAction) -> String:
 	return await _materialized_as_richtext_async(_materialize_action_input(action))
@@ -144,7 +144,7 @@ func action_as_text(action:GUIDEAction) -> String:
 	return _materialized_as_text(_materialize_action_input(action))
 
 ## Formats the input as richtext with icons suitable for a RichTextLabel. This function
-## is async as icons may need to be rendered in the background which can take a few frames, so 
+## is async as icons may need to be rendered in the background which can take a few frames, so
 ## you will need to await on it.
 func input_as_richtext_async(input:GUIDEInput, materialize_actions:bool = true) -> String:
 	return await _materialized_as_richtext_async(_materialize_input(input, materialize_actions))
@@ -153,8 +153,8 @@ func input_as_richtext_async(input:GUIDEInput, materialize_actions:bool = true) 
 ## Formats the input as plain text which can be used in any UI component. This is a bit
 ## more light-weight than formatting as icons and returns immediately.
 func input_as_text(input:GUIDEInput, materialize_actions:bool = true) -> String:
-	return _materialized_as_text(_materialize_input(input, materialize_actions))	
-	
+	return _materialized_as_text(_materialize_input(input, materialize_actions))
+
 
 ## Renders materialized input as text.
 func _materialized_as_text(input:MaterializedInput) -> String:
@@ -174,16 +174,16 @@ func _materialized_as_text(input:MaterializedInput) -> String:
 	var separator = _separator_for_input(input)
 	if separator == "" or input.parts.is_empty():
 		return ""
-		
+
 	var parts:Array[String] = []
 	for part in input.parts:
-		parts.append(_materialized_as_text(part))	
-		
+		parts.append(_materialized_as_text(part))
+
 	return separator.join(parts)
-			
+
 ## Renders materialized input as rich text.
 func _materialized_as_richtext_async(input:MaterializedInput) -> String:
-	_ensure_readiness()	
+	_ensure_readiness()
 	if input is MaterializedSimpleInput:
 		var icon:Texture2D = null
 		for renderer in _icon_renderers:
@@ -194,25 +194,24 @@ func _materialized_as_richtext_async(input:MaterializedInput) -> String:
 		if icon == null:
 			push_warning("No renderer found for input ", input)
 			return ""
-		
+
 		return "[img]%s[/img]" % [icon.resource_path]
-	
+
 
 	var separator = _separator_for_input(input)
 	if separator == "" or input.parts.is_empty():
 		return ""
-		
+
 	var parts:Array[String] = []
 	for part in input.parts:
-		parts.append(await _materialized_as_richtext_async(part))	
-		
+		parts.append(await _materialized_as_richtext_async(part))
+
 	return separator.join(parts)
-		
+
 ## Formats the action input as a Texture2D. This function
-## is async as icons may need to be rendered in the background which can take a few frames, so 
+## is async as icons may need to be rendered in the background which can take a few frames, so
 ## you will need to await on it.
 func action_as_texture_async(action:GUIDEAction) -> Texture2D:
-	print(_materialize_action_input(action))
 	return await _materialized_as_texture_async(_materialize_action_input(action))
 
 ## Renders materialized input as texture.
@@ -243,27 +242,27 @@ func _separator_for_input(input:MaterializedInput) -> String:
 
 	push_error("Unknown materialized input type")
 	return ""
-			
 
-## Materializes action input.	
+
+## Materializes action input.
 func _materialize_action_input(action:GUIDEAction) -> MaterializedInput:
 	var result := MaterializedMixedInput.new()
 	if action == null:
 		push_warning("Trying to get inputs for a null action.")
 		return result
-	
+
 	# get the mapping for this action
 	var mapping:GUIDEActionMapping = _action_resolver.call(action)
-	
+
 	# if we have no mapping, well that's it, return an empty mixed input
 	if mapping == null:
 		return result
-		
+
 	# collect input mappings
 	for input_mapping in mapping.input_mappings:
 		var chorded_actions:Array[MaterializedInput] = []
 		var combos:Array[MaterializedInput] = []
-		
+
 		for trigger in input_mapping.triggers:
 			# if we have a combo trigger, materialize its input.
 			if trigger is GUIDETriggerCombo:
@@ -285,29 +284,29 @@ func _materialize_action_input(action:GUIDEAction) -> MaterializedInput:
 				chord.parts.append(combo)
 			if combos.is_empty():
 				if input_mapping.input != null:
-					chord.parts.append(_materialize_input(input_mapping.input))					
+					chord.parts.append(_materialize_input(input_mapping.input))
 			result.parts.append(chord)
 		else:
 			for combo in combos:
 				result.parts.append(combo)
 			if combos.is_empty():
 				if input_mapping.input != null:
-					result.parts.append(_materialize_input(input_mapping.input))			
+					result.parts.append(_materialize_input(input_mapping.input))
 	return result
-	
+
 ## Materializes direct input.
 func _materialize_input(input:GUIDEInput, materialize_actions:bool = true) -> MaterializedInput:
 	if input == null:
 		push_warning("Trying to materialize a null input.")
 		return MaterializedMixedInput.new()
-	
+
 	# if its an action input, get its parts
 	if input is GUIDEInputAction:
 		if materialize_actions:
 			return _materialize_action_input(input.action)
 		else:
 			return MaterializedSimpleInput.new(input)
-	
+
 	# if its a key input, split out the modifiers
 	if input is GUIDEInputKey:
 		var chord := MaterializedChordedInput.new()
@@ -327,35 +326,35 @@ func _materialize_input(input:GUIDEInput, materialize_actions:bool = true) -> Ma
 			var meta = GUIDEInputKey.new()
 			meta.key = KEY_META
 			chord.parts.append(MaterializedSimpleInput.new(meta))
-	
+
 		# got no modifiers?
 		if chord.parts.is_empty():
 			return MaterializedSimpleInput.new(input)
-			
-		chord.parts.append(MaterializedSimpleInput.new(input))	
+
+		chord.parts.append(MaterializedSimpleInput.new(input))
 		return chord
 
 	# everything else is just a simple input
 	return MaterializedSimpleInput.new(input)
-			
+
 class MaterializedInput:
 	pass
-	
+
 class MaterializedSimpleInput:
 	extends MaterializedInput
-	var input:GUIDEInput	
-	
+	var input:GUIDEInput
+
 	func _init(input:GUIDEInput):
 		self.input = input
-	
+
 class MaterializedMixedInput:
 	extends MaterializedInput
 	var parts:Array[MaterializedInput] = []
-	
+
 class MaterializedChordedInput:
 	extends MaterializedInput
 	var parts:Array[MaterializedInput] = []
-	
+
 class MaterializedComboInput:
 	extends MaterializedInput
 	var parts:Array[MaterializedInput] = []
@@ -363,20 +362,20 @@ class MaterializedComboInput:
 
 ## Returns the name of the associated joystick/pad of the given input.
 ## If the input is no joy input or the device name cannot be determined
-## returns an empty string. 
+## returns an empty string.
 static func _joy_name_for_input(input:GUIDEInput) -> String:
 	if not input is GUIDEInputJoyBase:
 		return ""
-	
+
 	var joypads:Array[int] = Input.get_connected_joypads()
 	var joy_index = input.joy_index
 	if joy_index < 0:
 		# pick the first one
 		joy_index = 0
-	
+
 	# We don't have such a controller, so bail out.
 	if joypads.size() <= joy_index:
-		return "" 
-		
+		return ""
+
 	var id = joypads[joy_index]
-	return Input.get_joy_name(id)	
+	return Input.get_joy_name(id)


### PR DESCRIPTION
I wanted to set a texture with the formatter. Could probably be done in a resource for easier use, but for now it works as a basic prototype.

Submitting as an idea for enhancements, willing to polish a bit if you like the idea. It only renders the first part if there are multiple

```gdscript
class_name PromptTexture extends TextureRect

## The actions which should be used for rendering the instructions. One action for
## each %s in the text.
@export var action : GUIDEAction
## The icon size to be used for rendering.
@export var icon_size:int = 48

## If set, the label will only show when the given mapping context is active.
@export var limit_to_context:GUIDEMappingContext

# The formatter. This will do the actual work of formatting action inputs into prompts.
var _formatter:GUIDEInputFormatter

func _ready() -> void:
	# Subscribe to the input mappings change so we can update the prompts or hide the label
	# when any inputs change. This way the label can automatically update itself if we switch
	# from keyboard to controller input or rebind some keys.
	GUIDE.input_mappings_changed.connect(_update_texture)
	_formatter = GUIDEInputFormatter.for_active_contexts(icon_size)
	_update_texture()

func _update_texture() -> void:
	# If we only show for a certain context, hide if that context isn't active right now.
	if limit_to_context != null and not GUIDE.is_mapping_context_enabled(limit_to_context):
		visible = false
		return

	# if no mapping context is active, we'll not be able to show instructions, so bail out here.
	if GUIDE.get_enabled_mapping_contexts().is_empty():
		visible = false
		return

	visible = true

	# Update the prompt.
	# print(await _formatter.action_as_texture_async(action))
	texture = await _formatter.action_as_texture_async(action)
```