### PR TITLE
Suggestion: Add enabled/disabled signals for mapping contexts

### DIFF
--- a/addons/guide/guide.gd
+++ b/addons/guide/guide.gd
@@ -92,6 +92,7 @@ func enable_mapping_context(context:GUIDEMappingContext, disable_others:bool = f
 		_active_contexts.clear()	
 	
 	_active_contexts[context] = priority
+	context.enabled.emit()
 	_update_caches()
 	
 	
@@ -102,6 +103,7 @@ func disable_mapping_context(context:GUIDEMappingContext):
 		return
 
 	_active_contexts.erase(context)
+	context.disabled.emit()
 	_update_caches()
 
 

--- a/addons/guide/guide.gd
+++ b/addons/guide/guide.gd
@@ -92,8 +92,9 @@ func enable_mapping_context(context:GUIDEMappingContext, disable_others:bool = f
 		_active_contexts.clear()	
 	
 	_active_contexts[context] = priority
-	context.enabled.emit()
 	_update_caches()
+	# notify listeners that the context was enabled
+	context.enabled.emit()
 	
 	
 ## Disables the given mapping context.
@@ -103,8 +104,9 @@ func disable_mapping_context(context:GUIDEMappingContext):
 		return
 
 	_active_contexts.erase(context)
-	context.disabled.emit()
 	_update_caches()
+	# notify listeners that the context was disabled
+	context.disabled.emit()
 
 
 ## Checks whether the given mapping context is currently enabled.

--- a/addons/guide/guide_mapping_context.gd
+++ b/addons/guide/guide_mapping_context.gd
@@ -3,6 +3,9 @@
 class_name GUIDEMappingContext
 extends Resource
 
+signal enabled
+signal disabled
+
 const GUIDESet = preload("guide_set.gd")
 
 ## The display name for this mapping context during action remapping 

--- a/addons/guide/guide_mapping_context.gd
+++ b/addons/guide/guide_mapping_context.gd
@@ -3,8 +3,11 @@
 class_name GUIDEMappingContext
 extends Resource
 
-signal enabled
-signal disabled
+## Emitted when this mapping context is enabled.
+signal enabled()
+
+## Emitted when this mapping context is disabled.
+signal disabled()
 
 const GUIDESet = preload("guide_set.gd")
 

--- a/docs/_docs/usage/02_configuration_and_input_handling.md
+++ b/docs/_docs/usage/02_configuration_and_input_handling.md
@@ -238,6 +238,23 @@ The `enable_mapping_context` function also has a second boolean parameter `disab
 GUIDE.enable_mapping_context(my_mapping_context, true)
 ```
 
+Mapping contexts also provide an `enabled` and `disabled` signal which can be used to get notified when a mapping context is enabled or disabled. This can be useful for triggering additional actions when a mapping context becomes active or inactive. For example we can show or hide certain UI elements depending on the currently active mapping context.
+
+```gdscript
+@export var my_mapping_context:GUIDEMappingContext
+
+func _ready():
+    my_mapping_context.enabled.connect(_on_mapping_context_enabled)
+    my_mapping_context.disabled.connect(_on_mapping_context_disabled)
+
+func _on_mapping_context_enabled():
+    # Show some UI elements
+    ...
+    
+func _on_mapping_context_disabled():
+    # Hide some UI elements
+    ...
+```
 
 ### Mapping context action priority
 


### PR DESCRIPTION
Fairly simple pull request, but this is a feature that has helped me in my own projects. Overall, I've found that it makes things much more deterministic. Instead of listening for an action triggered signal for a pause menu (which may or may not fire after the in-game context is disabled), I can just listen for when the context for the pause menu is enabled/disabled. 